### PR TITLE
refactor: css colors #123

### DIFF
--- a/src/lib/components/DetailsMain.svelte
+++ b/src/lib/components/DetailsMain.svelte
@@ -158,7 +158,7 @@
 	article {
 		display: flex;
 		flex-direction: column;
-		background-color: var(--oklch-accent-secondary);
+		background-color: var(--color-accent-secondary);
 		border-radius: var(--child-radius);
 		box-shadow: var(--box-shadow-img-article);
 		padding: 0.8em;

--- a/src/lib/components/ProjectCard.svelte
+++ b/src/lib/components/ProjectCard.svelte
@@ -56,7 +56,7 @@
 		&:hover,
 		&:focus-within {
 			background-color: var(--dark-2);
-			outline: 2px solid var(--light-2);
+			outline: 1px solid var(--light-2);
 			box-shadow: 1px 1px 5px 10px var(--dark-1);
 			scale: 1.01;
 			transition: scale 0.2s ease-in;

--- a/src/lib/components/SponsorCarousel.svelte
+++ b/src/lib/components/SponsorCarousel.svelte
@@ -34,7 +34,7 @@
 
 <style>
 	.sponsors {
-		background: var(--oklch-neutral);
+		background: var(--color-neutral);
 		color: var(--color-accent-primary);
 		min-height: 57vh;
 		display: flex;

--- a/static/styles/styleguide.css
+++ b/static/styles/styleguide.css
@@ -5,19 +5,11 @@
 }
 
 body {
-    --color-primary: hsl(0 0% 100%);
-    --color-dark: hsl(0, 0%, 0%);
-    --color-neutral: hsl(201, 72%, 18%);
-    --color-accent-primary: hsl(167, 38%, 67%);
-    --color-accent-secondary: hsl(34, 49%, 85%);
-
-    @supports (color: oklch(50% 0.1 120)) {
-        --oklch-primary: oklch(100.00% 0.000 0);
-        --oklch-dark: oklch(0.00% 0.000 0);
-        --oklch-neutral: oklch(32.79% 0.063 237.53); 
-        --oklch-accent-primary: oklch(79.49% 0.068 179.24);
-        --oklch-accent-secondary: oklch(89.63% 0.035 74.39);
-    }
+    --color-primary: #ffffff;
+    --color-dark: #000000;
+    --color-neutral: #0d3951;
+    --color-accent-primary: #8bcbbd;
+    --color-accent-secondary: #ebdac4;
 
     /* font */
     font-family: 'Geomanist', sans-serif;
@@ -41,48 +33,41 @@ body {
 }
 
 /* ====================================================== COLORS ====================================================== */
-.primary,
-.dark,
 .neutral,
 .accent-primary,
 .accent-secondary {
-    --dark-2: color-mix(in hsl, var(--color) 90%, black 10%);
-    --dark-1: color-mix(in hsl, var(--color) 95%, black 5%);
-    --light-1: color-mix(in hsl, var(--color) 90%, white 10%);
-    --light-2: color-mix(in hsl, var(--color) 80%, white 20%);
+	--dark-2: color-mix(in hsl, var(--place-holder) 80%, black 20%);
+	--dark-1: color-mix(in hsl, var(--place-holder) 90%, black 10%);
+	--color: color-mix(in hsl, var(--place-holder) 100%, white 0%);
+	--light-1: color-mix(in hsl, var(--place-holder) 100%, white 2%);
+	--light-2: color-mix(in hsl, var(--place-holder) 100%, white 7%);
 
-    @supports (color: oklch(50% 0.1 120)) {
-        --dark-2: oklch(from var(--color) calc(l - 0.10) calc(c - 0.02) h);
-        --dark-1: oklch(from var(--color) calc(l - 0.04) calc(c - 0.01) h);
-        --light-1: oklch(from var(--color) calc(l + 0.02) calc(c + 0.01) h);
-        --light-2: oklch(from var(--color) calc(l + 0.04) calc(c + 0.02) h);
-    }
-}
-
-.primary {
-    --color: var(--oklch-primary, var(--color-primary));
-}
-
-.dark {
-    --color: var(--oklch-dark, var(--color-dark));
+	@supports (color: oklch(50% 0.1 120)) {
+		--dark-2: oklch(from var(--place-holder) calc(l - 0.10) calc(c + 0.02) h);
+		--dark-1: oklch(from var(--place-holder) calc(l - 0.04) calc(c + 0.01) h);
+		--color: oklch(from var(--place-holder) l c h);
+		--light-1: oklch(from var(--place-holder) calc(l + 0.02) calc(c + 0.01) h);
+		--light-2: oklch(from var(--place-holder) calc(l + 0.04) calc(c + 0.02) h);
+	}
 }
 
 .neutral {
-    --color: var(--oklch-neutral, var(--color-neutral));
+    --place-holder: var(--color-neutral);
 }
 
 .accent-primary {
-    --color: var(--oklch-accent-primary, var(--color-accent-primary));
+    --place-holder: var(--color-accent-primary);
 }
 
 .accent-secondary {
-    --color: var(--oklch-accent-secondary, var(--color-accent-secondary));
+    --place-holder: var(--color-accent-secondary);
 }
 
 /* ====================================================== FONTS ====================================================== */
 @font-face {
-    font-family: 'Merriweather';
-    src: url('/fonts/Merriweather-Regular.f56f3e.woff2') format('woff2');
+    font-family: 'Geomanist';
+    src: url('/fonts/geomanist-regular.woff2') format('woff2'),
+        url('/fonts/hinted-Geomanist-Regular.woff') format('woff');
     font-weight: 400;
     font-style: normal;
     font-display: swap;
@@ -90,15 +75,8 @@ body {
 
 @font-face {
     font-family: 'Geomanist';
-    src: url('/fonts/geomanist-regular.woff2') format('woff2');
-    font-weight: 400;
-    font-style: normal;
-    font-display: swap;
-}
-
-@font-face {
-    font-family: 'Geomanist';
-    src: url('/fonts/geomanist-bold-webfont.29a44a.woff2') format('woff2');
+    src: url('/fonts/geomanist-bold-webfont.29a44a.woff2') format('woff2'),
+        url('/fonts/hinted-Geomanist-Bold.woff') format('woff');
     font-weight: 600;
     font-style: normal;
     font-display: swap;
@@ -106,7 +84,8 @@ body {
 
 @font-face {
     font-family: 'Geomanist';
-    src: url('/fonts/geomanist-regular-italic-webfont.woff2') format('woff2');
+    src: url('/fonts/geomanist-regular-italic-webfont.woff2') format('woff2'),
+        url('/fonts/geomanist-regular-italic-webfont.woff') format('woff');
     font-style: italic;
     font-display: swap;
 }


### PR DESCRIPTION
## What does this change?

Resolves issue #123

I’ve updated our colors. Previously, we had separate custom properties for HSL and OKLCH, but this wasn’t necessary because oklch(), the color function, and color-mix() can all take hex colors (hsl and oklch aswel) and output OKLCH or HSL.  
The conversion happens automatically in CSS.

By replacing the custom properties for HSL and OKLCH with just one, it’s now much easier to maintain and update our colors when needed, since we only need to change a single custom property.

I also removed color-primary and color-dark from the calculations, because we don’t need color variations for those.

[In this article](https://vsheo.github.io/i-love-web/CSS-color-generator/), I explain how it works, and here is the [CodePen version](https://codepen.io/vrsh/pen/emZVWQw) where the colors for this project are displayed side by side.

Lastly, I’ve slightly tweaked the fallback color-mix variations to better match the OKLCH versions.

## Images
## OKLCH Comparison

| Old Version | New Version |
|------------|-------------|
| <img width="350" src="https://github.com/user-attachments/assets/7ed532c6-f6ce-46a4-a924-022a9a4d57fb" /> | <img width="350" src="https://github.com/user-attachments/assets/c260e3d1-2a29-4443-b20b-94ad787d0dbb" /> |

---

## color-mix Comparison

| Old Version | New Version |
|------------|-------------|
| <img width="350" src="https://github.com/user-attachments/assets/f8444053-9412-4c24-b392-4a681e858078" /> | <img width="350" src="https://github.com/user-attachments/assets/7977ff36-e297-4852-93f3-f0418e583619" /> |



## How to review
Please review the color updates and share your feedback.
