### PR TITLE
108 modular scale for typography

### DIFF
--- a/src/lib/atoms/Logo.svelte
+++ b/src/lib/atoms/Logo.svelte
@@ -18,7 +18,7 @@
 	a {
 		display: block;
 		width: 100%;
-		max-width: 580px;
+		max-width: 590px;
 		text-decoration: none;
 	}
 
@@ -50,7 +50,7 @@
 		display: none;
 	}
 
-	@container row-logo (min-width: 580px) {
+	@container row-logo (min-width: 590px) {
 		.logo-text {
 			flex-direction: row;
 		}

--- a/src/lib/molecules/ProjectCard.svelte
+++ b/src/lib/molecules/ProjectCard.svelte
@@ -18,18 +18,18 @@
 			<img src={fallBackimg} width="270px" height="250px" alt="image die te maken heeft met {img}" loading="lazy" />
 		</picture>
 
+		{#if description}
+			<p class="description">{description}</p>
+		{:else}
+			<p class="description"><i>Description is missing</i></p>
+		{/if}
+
 		{#if date && !end_date}
 			<p class="date">{new Date(date).getFullYear()}</p>
 		{:else if date && end_date}
 			<p class="date">{new Date(date).getFullYear()} / {new Date(end_date).getFullYear()}</p>
 		{:else}
 			<p class="empty-element"></p>
-		{/if}
-
-		{#if description}
-			<p class="description">{description}</p>
-		{:else}
-			<p class="description"><i>Description is missing</i></p>
 		{/if}
 	</a>
 </article>
@@ -45,6 +45,7 @@
 	.card-info {
 		display: grid;
 		width: 100%;
+		height: 100%;
 		text-decoration: none;
 		background-color: var(--light-2);
 		color: var(--color-primary);
@@ -68,7 +69,7 @@
 		}
 
 		h3 {
-			grid-row: 3;
+			grid-row: 2;
 		}
 
 		img {
@@ -76,13 +77,12 @@
 			object-fit: cover;
 			object-position: top;
 			border-radius: var(--radius) var(--radius) 0 0;
-			margin-bottom: 1rem;
 		}
 
 		h3,
 		.date,
 		.description {
-			padding: 0 1rem 1rem 1rem;
+			padding: 0 1rem;
 		}
 
 		.description {
@@ -91,30 +91,22 @@
 			-webkit-box-orient: vertical;
 			text-overflow: ellipsis;
 			-webkit-line-clamp: 7;
-			height: calc(1.5em * 5.8);
-			margin: 1em 0;
+			height: calc(1.5em * 5.15);
+			margin: 0.5rem 0 1rem 0;
+		}
+
+		.date {
+			margin: 0 0 1rem 0;
 		}
 	}
 
 	@container project-card (min-width: 385px) {
 		.card-info {
-			height: 34em;
-
-			h3 {
-				padding: 0 1rem;
-			}
+			grid-template-rows: min-content min-content min-content min-content;
 
 			img {
 				margin-bottom: 0;
-				height: 100%;
-			}
-
-			.date {
-				padding: 1rem 1rem 0 1rem;
-			}
-
-			.description {
-				margin: 0;
+				height: 250px;
 			}
 		}
 	}
@@ -126,7 +118,7 @@
 			height: 100%;
 
 			h3 {
-				grid-row: 2/3;
+				grid-row: 1/2;
 				grid-column: 2;
 				align-self: end;
 				padding: 0 1rem;
@@ -145,18 +137,12 @@
 			}
 
 			.date {
-				margin-top: 1rem;
-				padding: 0 1rem;
 				align-self: end;
 			}
 
 			.description {
-				grid-column: 2;
-				grid-row: 3;
-				margin-bottom: 1rem;
-				padding-top: 0.5rem;
 				-webkit-line-clamp: 5;
-				height: calc(1.5em * 4.4);
+				height: calc(1.5em * 3.4);
 			}
 		}
 	}

--- a/src/lib/organisms/About.svelte
+++ b/src/lib/organisms/About.svelte
@@ -32,7 +32,11 @@
 		flex-direction: column;
 		align-items: center;
 		background-color: var(--color);
-		margin-bottom: 2rem;
+		padding: var(--spacing-l) 0 var(--spacing-m) 0;
+
+		h2 {
+			margin-bottom: var(--spacing-m);
+		}
 	}
 
 	p {
@@ -46,7 +50,7 @@
 		align-items: center;
 		gap: 1em;
 		padding: 0;
-		margin: 0 1em;
+		margin: var(--spacing-m) 1em 0 1em;
 
 		@media (min-width: 600px) and (prefers-reduced-motion: no-preference) {
 			flex-direction: row;
@@ -81,7 +85,7 @@
 			width: 250px;
 
 			@media (min-width: 350px) {
-				width: 290px;
+				width: 310px;
 			}
 
 			h3 {

--- a/src/lib/organisms/About.svelte
+++ b/src/lib/organisms/About.svelte
@@ -42,6 +42,7 @@
 	p {
 		width: clamp(25ch, 90%, 85ch);
 		line-height: 1.5rem;
+		margin-bottom: var(--spacing-m);
 	}
 
 	ul {
@@ -50,7 +51,7 @@
 		align-items: center;
 		gap: 1em;
 		padding: 0;
-		margin: var(--spacing-m) 1em 0 1em;
+		margin: 0 1em 0 1em;
 
 		@media (min-width: 600px) and (prefers-reduced-motion: no-preference) {
 			flex-direction: row;

--- a/src/lib/organisms/DetailsMain.svelte
+++ b/src/lib/organisms/DetailsMain.svelte
@@ -180,7 +180,7 @@
 		align-items: center;
 
 		p {
-			width: clamp(25ch, 85%, 85ch);
+			width: clamp(25ch, 90%, 85ch);
 			margin-bottom: 2em;
 		}
 

--- a/src/lib/organisms/DetailsMain.svelte
+++ b/src/lib/organisms/DetailsMain.svelte
@@ -2,7 +2,6 @@
 	import { backButton } from '$lib'
 	export let projectsDetails
 	const { title, img, date, end_date, content } = projectsDetails
-
 </script>
 
 <section class="content-container primary">
@@ -120,7 +119,7 @@
 		}
 
 		span {
-			font-size: var(--font-size-primary);
+			font-size: 18px;
 			font-style: italic;
 		}
 	}

--- a/src/lib/organisms/DetailsMain.svelte
+++ b/src/lib/organisms/DetailsMain.svelte
@@ -180,13 +180,14 @@
 		align-items: center;
 
 		p {
-			width: clamp(25ch, 75%, 85ch);
+			width: clamp(25ch, 85%, 85ch);
+			margin-bottom: 2em;
 		}
 
 		strong {
 			display: inline-block;
 			font-size: var(--font-size-title-paragraph);
-			margin: 0.5em 0 0.5em 0;
+			margin-bottom: 0.5em;
 		}
 	}
 

--- a/src/lib/organisms/Filters.svelte
+++ b/src/lib/organisms/Filters.svelte
@@ -33,8 +33,6 @@
 	<form {...filterProjects}>
 		<h2>Filteren</h2>
 
-		<p class="keyboard-info">Klik op de spatiebalk om het filter aan te vinken</p>
-
 		<fieldset>
 			{#each ['Concept', 'Uitgevoerd', 'experiment', 'Methode'] as value}
 				<label>
@@ -102,18 +100,8 @@
 		display: flex;
 		flex-direction: column;
 		align-items: center;
-		margin: 5em 2em 2em 2em;
-		gap: 2em;
-	}
-
-	.keyboard-info {
-		padding: 0.5em;
-		font-size: 1.3rem;
-		background: var(--color-accent-secondary);
-		color: var(--color-dark);
-		border-radius: 20px;
-		white-space: nowrap;
-		opacity: 0;
+		margin: var(--spacing-l) 2em var(--spacing-m) 2em;
+		gap: var(--spacing-s);
 	}
 
 	form:has(input:focus-visible) .keyboard-info {
@@ -124,7 +112,7 @@
 		display: grid;
 		grid-template-columns: 1fr 1fr;
 		border: none;
-		gap: 0.5em;
+		gap: var(--spacing-s);
 	}
 
 	label {
@@ -162,19 +150,16 @@
 		display: flex;
 		flex-direction: column;
 		align-items: center;
-		gap: 0.5em;
+		gap: var(--spacing-s);
 
 		button {
 			border: none;
-
-			&:nth-of-type(1) {
-				margin-bottom: 1.2em;
-			}
 		}
 	}
 
 	.filter-results {
 		opacity: 0;
+		position: absolute;
 	}
 
 	@container filters (min-width: 545px) {
@@ -184,6 +169,10 @@
 			flex-wrap: wrap;
 			justify-content: center;
 			gap: 2em;
+		}
+
+		.form-buttons {
+			flex-direction: row;
 		}
 	}
 </style>

--- a/src/lib/organisms/Filters.svelte
+++ b/src/lib/organisms/Filters.svelte
@@ -102,6 +102,10 @@
 		align-items: center;
 		margin: var(--spacing-l) 2em var(--spacing-m) 2em;
 		gap: var(--spacing-s);
+
+		h2 {
+			margin-bottom: var(--spacing-s);
+		}
 	}
 
 	form:has(input:focus-visible) .keyboard-info {

--- a/src/lib/organisms/FooterInfo.svelte
+++ b/src/lib/organisms/FooterInfo.svelte
@@ -38,8 +38,9 @@
 				href="#partners"
 				on:click|preventDefault={toggleSponsors}
 				style="font-weight: 600; color: black; font-style:italic; text-decoration:none;"
-				role="button">Onze Partners</a
-			>
+				role="button"
+				>Onze Partners
+			</a>
 		</section>
 
 		<section class="footer-right">
@@ -63,47 +64,50 @@
 <style>
 	.footer {
 		background-color: var(--color-accent-secondary);
+		padding: var(--spacing-l) 3em;
+
+		.footer-left h2,
+		.footer-right h2 {
+			margin-top: var(--spacing-l);
+			margin-bottom: var(--spacing-s);
+		}
 
 		@media (min-width: 768px) {
-			padding: 0rem 0vw;
+			padding: 0 0 3em 0;
 		}
 	}
 
 	.footer-container {
 		display: flex;
 		flex-direction: column;
-		gap: 2rem;
-		max-width: 1400px;
+		gap: var(--spacing-l);
 		margin-inline: auto;
-		padding: 0 3em;
 
 		@media (min-width: 768px) {
 			flex-direction: row;
 			justify-content: space-between;
 			align-items: flex-start;
-			gap: 16rem;
+			gap: 8rem;
+			margin: 0 3em;
 		}
 
 		@media (min-width: 1024px) {
 			justify-content: center;
+			margin: 0;
 		}
 	}
 
-	/* kolommen */
 	.footer-left,
 	.footer-right {
 		display: flex;
 		flex-direction: column;
-		gap: 1.5rem;
-		margin-top: 1em;
-		margin-bottom: 2em;
+		gap: var(--spacing-s);
 
 		@media (min-width: 768px) {
 			max-width: 500px;
 		}
 	}
 
-	/* titels & tekst */
 	.project-title,
 	.community-heading {
 		font-size: var(--font-size-title-paragraph);
@@ -114,7 +118,6 @@
 		max-width: clamp(40ch, 80vw, 50ch);
 	}
 
-	/* contact */
 	.contact-block {
 		display: flex;
 		flex-direction: column;
@@ -127,7 +130,6 @@
 		}
 	}
 
-	/* nav */
 	.footer-nav {
 		display: flex;
 		flex-direction: column;
@@ -154,13 +156,11 @@
 		}
 	}
 
-	/* brandblok + logo */
 	.brand-block {
 		display: flex;
 		align-items: flex-start;
 		flex-wrap: wrap;
 		gap: 1rem;
-		margin-top: 1.5rem;
 	}
 
 	.brand-left {

--- a/src/lib/organisms/FooterInfo.svelte
+++ b/src/lib/organisms/FooterInfo.svelte
@@ -69,7 +69,6 @@
 		.footer-left h2,
 		.footer-right h2 {
 			margin-top: var(--spacing-l);
-			margin-bottom: var(--spacing-s);
 		}
 
 		@media (min-width: 768px) {
@@ -114,8 +113,8 @@
 	}
 
 	.community-text {
-		line-height: 1.5;
 		max-width: clamp(40ch, 80vw, 50ch);
+		margin-bottom: 2em;
 	}
 
 	.contact-block {

--- a/src/lib/organisms/FooterInfo.svelte
+++ b/src/lib/organisms/FooterInfo.svelte
@@ -5,18 +5,16 @@
 	export let sponsorsData
 
 	// JS disabled functie
-	import { onMount } from 'svelte';
-let showSponsors = true    
-onMount(() => {
-showSponsors = false
-});
-const toggleSponsors = () => {
-showSponsors = !showSponsors
-if (showSponsors)
-    requestAnimationFrame(() =>
-    document.querySelector('.sponsors')?.scrollIntoView({ behavior: 'smooth' })
-    )
-}
+	import { onMount } from 'svelte'
+	let showSponsors = true
+	onMount(() => {
+		showSponsors = false
+	})
+	// toggle
+	const toggleSponsors = () => {
+		showSponsors = !showSponsors
+		if (showSponsors) requestAnimationFrame(() => document.querySelector('.sponsors')?.scrollIntoView({ behavior: 'smooth' }))
+	}
 </script>
 
 <footer class="footer">
@@ -32,17 +30,16 @@ if (showSponsors)
 			</address>
 
 			<nav class="footer-nav">
-				<a href="partners">About this project</a>
-				<a
-				href="partners"
-				on:click|preventDefault={toggleSponsors}
-				role="button"
-				
-			>
-				Partners
-			</a>
+				<a href="about">About this project</a>
 				<a href="signal">Signal</a>
 			</nav>
+
+			<a
+				href="#partners"
+				on:click|preventDefault={toggleSponsors}
+				style="font-weight: 600; color: black; font-style:italic; text-decoration:none;"
+				role="button">Onze Partners</a
+			>
 		</section>
 
 		<section class="footer-right">
@@ -60,13 +57,8 @@ if (showSponsors)
 			</section>
 		</section>
 	</section>
-	<SponsorCarousel
-	{sponsorsData} 
-	visible={showSponsors}
-	/>
+	<SponsorCarousel {sponsorsData} visible={showSponsors} />
 </footer>
-
-
 
 <style>
 	.footer {
@@ -77,7 +69,6 @@ if (showSponsors)
 		}
 	}
 
-	/* layout */
 	.footer-container {
 		display: flex;
 		flex-direction: column;
@@ -106,7 +97,7 @@ if (showSponsors)
 		gap: 1.5rem;
 		margin-top: 1em;
 		margin-bottom: 2em;
-		
+
 		@media (min-width: 768px) {
 			max-width: 500px;
 		}
@@ -143,12 +134,12 @@ if (showSponsors)
 		gap: 1rem;
 
 		@media (min-width: 768px) {
-			gap: 2rem;
+			gap: 0.5rem;
 		}
 
 		@media (min-width: 1024px) {
 			flex-direction: row;
-			gap: 2.5rem;
+			gap: 1em;
 			white-space: nowrap;
 		}
 
@@ -177,8 +168,4 @@ if (showSponsors)
 		flex-direction: column;
 		font-weight: 600;
 	}
-
-	
 </style>
-
-

--- a/src/lib/organisms/Header.svelte
+++ b/src/lib/organisms/Header.svelte
@@ -62,7 +62,7 @@
 		position: relative;
 		justify-content: space-between;
 		background-color: var(--color-accent-secondary);
-		padding: 1em;
+		padding: var(--spacing-s);
 		z-index: 10;
 	}
 

--- a/src/lib/organisms/ProjectCardContainer.svelte
+++ b/src/lib/organisms/ProjectCardContainer.svelte
@@ -19,7 +19,7 @@
 	})
 </script>
 
-<section class="neutral projects-grid">
+<section class="neutral">
 	<h2 id="project-container" tabindex="-1">Projecten</h2>
 
 	{#each Allprojects as project (project.id)}
@@ -30,8 +30,8 @@
 <style>
 	section {
 		display: grid;
-		gap: 2.5em;
-		padding: 5em 1em;
+		gap: var(--spacing-m);
+		padding: var(--spacing-l) 1em var(--spacing-m) 1em;
 		background-color: var(--color);
 
 		h2 {
@@ -43,12 +43,12 @@
 		@media (min-width: 420px) {
 			grid-template-columns: repeat(auto-fit, minmax(375px, 1fr));
 			align-items: stretch;
-			padding: 5em clamp(1rem, 5vw, 5rem);
+			padding: var(--spacing-l) clamp(1rem, 5vw, 5rem);
 		}
 
 		@media (min-width: 1225px) {
-			grid-template-columns: repeat(2, minmax(375px, 1fr));
-			padding: 5em clamp(1rem, 15vw, 7rem);
+			grid-template-columns: repeat(3, 1fr);
+			padding: var(--spacing-l) clamp(1rem, 15vw, 7rem);
 		}
 	}
 </style>

--- a/static/styles/styleguide.css
+++ b/static/styles/styleguide.css
@@ -30,6 +30,14 @@ body {
     /* font-weight */
     --font-weight-regular: 400;
     --font-weight-bold: 600;
+
+    /* spacing */
+    --spacing-xl: 5rem;
+    --spacing-l: 4rem;
+    --spacing-m: 2rem;
+    --spacing-s: 1rem;
+    --spacing-xs: 0.5rem;
+
 }
 
 /* ====================================================== COLORS ====================================================== */

--- a/static/styles/styleguide.css
+++ b/static/styles/styleguide.css
@@ -11,11 +11,13 @@ body {
     --color-accent-primary: #8bcbbd;
     --color-accent-secondary: #ebdac4;
 
-    /* font */
+    /* text */
     font-family: 'Geomanist', sans-serif;
-    font-size: 18px;
+    font-size: 16px;
     font-weight: var(--font-weight-regular);
     line-height: 1.5;
+    letter-spacing: 0.06em;
+    word-spacing: 0.16em;
     
     /* font-size */
     /* 64px */

--- a/static/styles/styleguide.css
+++ b/static/styles/styleguide.css
@@ -13,11 +13,11 @@ body {
 
     /* font */
     font-family: 'Geomanist', sans-serif;
-    font-size: var(--font-size-primary);
+    font-size: 18px;
     font-weight: var(--font-weight-regular);
+    line-height: 1.5;
     
     /* font-size */
-    --font-size-primary: 1.125rem;
     /* 64px */
     --font-size-title-page: clamp(3rem, calc(8.5vw + 1rem), 4rem);
     /* 48px */

--- a/static/styles/styleguide.css
+++ b/static/styles/styleguide.css
@@ -20,14 +20,10 @@ body {
     word-spacing: 0.16em;
     
     /* font-size */
-    /* 64px */
-    --font-size-title-page: clamp(3rem, calc(8.5vw + 1rem), 4rem);
-    /* 48px */
-    --font-size-title-section: clamp(2.25rem, calc(6vw + 1rem), 3rem);
-    /* 36px */
-    --font-size-title-card: clamp(2rem, calc(5vw + 1rem), 2.25rem);
-    /* 28px */
-    --font-size-title-paragraph: clamp(1.35rem, calc(3vw + 1rem), 1.75rem);
+    --font-size-title-page: clamp(3.129rem, calc(8.5vw + 1rem), 4.162rem);
+    --font-size-title-section: clamp(2.353rem, calc(6vw + 1rem), 3.129rem);
+    --font-size-title-card: clamp(1.769rem, calc(5vw + 1rem), 2.353rem);
+    --font-size-title-paragraph: clamp(1.33rem, calc(3vw + 1rem), 1.769rem);
 
     /* font-weight */
     --font-weight-regular: 400;


### PR DESCRIPTION
## What does this change?

Resolves issue #108 

In this branch, I updated the font sizes to use a modular scale. I used the Perfect Fourth scale (1.33) because it closely matches our current typographic scale. As a result, no changes were needed to the surrounding elements.

## Images
Before:
<img width="3793" height="1807" alt="image" src="https://github.com/user-attachments/assets/fead892b-3ddd-4dc9-abc8-935da925b6bf" />


After:
<img width="3785" height="1815" alt="Schermafbeelding 2026-01-09 140222" src="https://github.com/user-attachments/assets/811411f4-1240-45d6-991f-16f1c51c87dd" />





## How to review
- Does the Perfect Fourth (1.33) scale logically fit with our existing typography?
- Are there areas where the scale feels too aggressive or, conversely, too subtle?
- Do you see any exceptions where deviating from the scale would be desirable?
