### PR TITLE
107 text alignment

### DIFF
--- a/src/lib/atoms/Logo.svelte
+++ b/src/lib/atoms/Logo.svelte
@@ -18,7 +18,7 @@
 	a {
 		display: block;
 		width: 100%;
-		max-width: 580px;
+		max-width: 590px;
 		text-decoration: none;
 	}
 
@@ -50,7 +50,7 @@
 		display: none;
 	}
 
-	@container row-logo (min-width: 580px) {
+	@container row-logo (min-width: 590px) {
 		.logo-text {
 			flex-direction: row;
 		}

--- a/src/lib/molecules/ProjectCard.svelte
+++ b/src/lib/molecules/ProjectCard.svelte
@@ -70,6 +70,7 @@
 
 		h3 {
 			grid-row: 2;
+			text-wrap: balance;
 		}
 
 		img {

--- a/src/lib/organisms/About.svelte
+++ b/src/lib/organisms/About.svelte
@@ -42,6 +42,7 @@
 	p {
 		width: clamp(25ch, 90%, 85ch);
 		line-height: 1.5rem;
+		margin-bottom: var(--spacing-m);
 	}
 
 	ul {
@@ -50,7 +51,7 @@
 		align-items: center;
 		gap: 1em;
 		padding: 0;
-		margin: var(--spacing-m) 1em 0 1em;
+		margin: 0 1em 0 1em;
 
 		@media (min-width: 600px) and (prefers-reduced-motion: no-preference) {
 			flex-direction: row;

--- a/src/lib/organisms/DetailsMain.svelte
+++ b/src/lib/organisms/DetailsMain.svelte
@@ -180,7 +180,7 @@
 		align-items: center;
 
 		p {
-			width: clamp(25ch, 85%, 85ch);
+			width: clamp(25ch, 90%, 85ch);
 			margin-bottom: 2em;
 		}
 

--- a/src/lib/organisms/DetailsMain.svelte
+++ b/src/lib/organisms/DetailsMain.svelte
@@ -180,13 +180,14 @@
 		align-items: center;
 
 		p {
-			width: clamp(25ch, 75%, 85ch);
+			width: clamp(25ch, 85%, 85ch);
+			margin-bottom: 2em;
 		}
 
 		strong {
 			display: inline-block;
 			font-size: var(--font-size-title-paragraph);
-			margin: 0.5em 0 0.5em 0;
+			margin-bottom: 0.5em;
 		}
 	}
 

--- a/src/lib/organisms/DetailsMain.svelte
+++ b/src/lib/organisms/DetailsMain.svelte
@@ -194,6 +194,10 @@
 	.text-fallback {
 		text-align: center;
 
+		h3 {
+			text-wrap: balance;
+		}
+
 		p {
 			line-height: 1.5rem;
 		}

--- a/src/lib/organisms/FooterInfo.svelte
+++ b/src/lib/organisms/FooterInfo.svelte
@@ -69,7 +69,6 @@
 		.footer-left h2,
 		.footer-right h2 {
 			margin-top: var(--spacing-l);
-			margin-bottom: var(--spacing-s);
 		}
 
 		@media (min-width: 768px) {
@@ -114,8 +113,8 @@
 	}
 
 	.community-text {
-		line-height: 1.5;
 		max-width: clamp(40ch, 80vw, 50ch);
+		margin-bottom: 2em;
 	}
 
 	.contact-block {

--- a/static/styles/styleguide.css
+++ b/static/styles/styleguide.css
@@ -11,11 +11,13 @@ body {
     --color-accent-primary: #8bcbbd;
     --color-accent-secondary: #ebdac4;
 
-    /* font */
+    /* text */
     font-family: 'Geomanist', sans-serif;
-    font-size: 18px;
+    font-size: 16px;
     font-weight: var(--font-weight-regular);
     line-height: 1.5;
+    letter-spacing: 0.06em;
+    word-spacing: 0.16em;
     
     /* font-size */
     /* 64px */

--- a/static/styles/styleguide.css
+++ b/static/styles/styleguide.css
@@ -20,14 +20,10 @@ body {
     word-spacing: 0.16em;
     
     /* font-size */
-    /* 64px */
-    --font-size-title-page: clamp(3rem, calc(8.5vw + 1rem), 4rem);
-    /* 48px */
-    --font-size-title-section: clamp(2.25rem, calc(6vw + 1rem), 3rem);
-    /* 36px */
-    --font-size-title-card: clamp(2rem, calc(5vw + 1rem), 2.25rem);
-    /* 28px */
-    --font-size-title-paragraph: clamp(1.35rem, calc(3vw + 1rem), 1.75rem);
+    --font-size-title-page: clamp(3.129rem, calc(8.5vw + 1rem), 4.162rem);
+    --font-size-title-section: clamp(2.353rem, calc(6vw + 1rem), 3.129rem);
+    --font-size-title-card: clamp(1.769rem, calc(5vw + 1rem), 2.353rem);
+    --font-size-title-paragraph: clamp(1.33rem, calc(3vw + 1rem), 1.769rem);
 
     /* font-weight */
     --font-weight-regular: 400;


### PR DESCRIPTION
## What does this change?

Resolves issue #107 

In issue #107, I reviewed whether we were following the [code conventions for text alignment](https://docs.fdnd.nl/conventies.html#text-alignment). In almost all cases, we use left-aligned text. We do not use right-aligned text. Center-aligned text is only used for the empty state on the details page.

We did not previously use text-wrap: balance, which I have now added to the titles of the project cards and to the title of the empty state on the details page


## Images

### project card title
Before:
<img width="1684" height="1189" alt="Image" src="https://github.com/user-attachments/assets/53fd621a-5a95-45c6-91f1-be31d6da1d5f" />

After:
<img width="1672" height="1188" alt="Image" src="https://github.com/user-attachments/assets/0474a1da-edf6-4399-b092-afd71608933d" />


### empty state title

Before:

https://github.com/user-attachments/assets/c684e424-5745-4794-be11-b5a96896ca6e

After:

https://github.com/user-attachments/assets/d468c8a7-0f25-4044-a511-d3c20aa74bab


## How to review
How do the titles look with text-wrap: balance?  
Please also consider how the titles appear across different screen sizes.  
Do you see this as an improvement, or was the previous version better?
