### PR TITLE
62 error page

### DIFF
--- a/src/lib/organisms/About.svelte
+++ b/src/lib/organisms/About.svelte
@@ -53,7 +53,7 @@
 		padding: 0;
 		margin: 0 1em 0 1em;
 
-		@media (min-width: 600px) and (prefers-reduced-motion: no-preference) {
+		@media (min-width: 630px) and (prefers-reduced-motion: no-preference) {
 			flex-direction: row;
 		}
 	}
@@ -86,7 +86,7 @@
 			width: 250px;
 
 			@media (min-width: 350px) {
-				width: 310px;
+				width: 325px;
 			}
 
 			h3 {

--- a/src/lib/organisms/DetailsMain.svelte
+++ b/src/lib/organisms/DetailsMain.svelte
@@ -12,7 +12,7 @@
 		<h2><i>Title is missing</i></h2>
 	{/if}
 
-	<button>
+	<button on:click={() => history.back()}>
 		<img src={backButton} width="36px" height="36px" alt="Terug naar de vorige pagina" />
 		<span>Terug</span>
 	</button>

--- a/src/lib/organisms/Filters.svelte
+++ b/src/lib/organisms/Filters.svelte
@@ -122,7 +122,7 @@
 		transition: background-color 0.2s ease-out;
 		position: relative;
 		background-color: var(--color-accent-secondary);
-		width: clamp(6em, 100%, 8.5em);
+		width: clamp(6em, 100%, 9.5em);
 
 		&:has(input:checked),
 		&:has(input:focus-visible),

--- a/src/lib/organisms/Filters.svelte
+++ b/src/lib/organisms/Filters.svelte
@@ -158,7 +158,7 @@
 		gap: var(--spacing-s);
 
 		button {
-			width: 8.5em;
+			width: 9.5em;
 			border: none;
 			background-color: var(--color-accent-primary);
 

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -27,7 +27,7 @@
 	<section>
 		<h2>{page.error?.message}</h2>
 		<p>Deze pagina bestaat helaas niet.</p>
-		<a href="/">Terug naar de homepagina</a>
+		<a href="/">Terug naar de home pagina</a>
 		<button on:click={() => history.back()}> Terug naar de vorige pagina</button>
 	</section>
 </article>
@@ -45,4 +45,15 @@
 	article {
 		margin: 5em 0;
 	}
+
+    a, button {
+        color: #0000EE;
+        font-size: var(--font-size-primary);
+    }
+
+    button {
+        border: none;
+        background-color: inherit;
+        text-decoration: underline;
+    }
 </style>

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -28,7 +28,7 @@
 		<h2>{page.error?.message}</h2>
 		<p>Deze pagina bestaat helaas niet.</p>
 		<a href="/">Terug naar de homepagina</a>
-		<a href="/">Terug naar de vorige pagina</a>
+		<button on:click={() => history.back()}> Terug naar de vorige pagina</button>
 	</section>
 </article>
 
@@ -39,10 +39,10 @@
 		flex-direction: column;
 		place-self: center;
 		text-align: center;
-        gap: 0.5em;
+		gap: 0.5em;
 	}
 
-    article {
-        margin: 5em 0;
-    }
+	article {
+		margin: 5em 0;
+	}
 </style>

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -1,0 +1,48 @@
+<script>
+	import { page } from '$app/state'
+</script>
+
+<article>
+	<svg
+		fill="#000000"
+		version="1.1"
+		id="Capa_1"
+		xmlns="http://www.w3.org/2000/svg"
+		xmlns:xlink="http://www.w3.org/1999/xlink"
+		viewBox="0 0 106.059 106.059"
+		xml:space="preserve"
+		><g id="SVGRepo_bgCarrier" stroke-width="0"></g><g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g><g
+			id="SVGRepo_iconCarrier"
+		>
+			<g>
+				<path
+					d="M90.546,15.518C69.858-5.172,36.199-5.172,15.515,15.513C-5.173,36.198-5.171,69.858,15.517,90.547 c20.682,20.684,54.341,20.684,75.027-0.004C111.23,69.858,111.229,36.2,90.546,15.518z M84.757,84.758 c-17.494,17.494-45.96,17.496-63.455,0.002c-17.498-17.497-17.496-45.966,0-63.46C38.796,3.807,67.261,3.805,84.759,21.302 C102.253,38.796,102.251,67.265,84.757,84.758z M77.017,74.001c0.658,1.521-0.042,3.286-1.562,3.943 c-1.521,0.66-3.286-0.042-3.944-1.562c-2.893-6.689-9.73-11.012-17.421-11.012c-7.868,0-14.747,4.319-17.522,11.004 c-0.479,1.154-1.596,1.851-2.771,1.851c-0.384,0-0.773-0.074-1.15-0.23c-1.53-0.636-2.255-2.392-1.62-3.921 c3.71-8.932,12.764-14.703,23.063-14.703C64.174,59.371,73.174,65.113,77.017,74.001z M33.24,38.671 c0-3.424,2.777-6.201,6.201-6.201c3.423,0,6.2,2.776,6.2,6.201c0,3.426-2.777,6.202-6.2,6.202 C36.017,44.873,33.24,42.097,33.24,38.671z M61.357,38.671c0-3.424,2.779-6.201,6.203-6.201c3.423,0,6.2,2.776,6.2,6.201 c0,3.426-2.776,6.202-6.2,6.202S61.357,42.097,61.357,38.671z"
+				></path>
+			</g>
+		</g></svg
+	>
+
+	<h1>{page.status}</h1>
+
+	<section>
+		<h2>{page.error?.message}</h2>
+		<p>Deze pagina bestaat helaas niet.</p>
+		<a href="/">Terug naar de homepagina</a>
+		<a href="/">Terug naar de vorige pagina</a>
+	</section>
+</article>
+
+<style>
+	article,
+	section {
+		display: flex;
+		flex-direction: column;
+		place-self: center;
+		text-align: center;
+        gap: 0.5em;
+	}
+
+    article {
+        margin: 5em 0;
+    }
+</style>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -9,8 +9,24 @@
 	<link rel="stylesheet" href="styles/styleguide.css" />
 </svelte:head>
 
-<Header />
+<div class="page-layout">
+	<Header />
 
-{@render children?.()}
+	<main>
+		{@render children?.()}
+	</main>
 
-<FooterInfo {sponsorsData} />
+	<FooterInfo {sponsorsData} />
+</div>
+
+<style>
+	.page-layout {
+		min-height: 100vh;
+		display: flex;
+		flex-direction: column;
+	}
+
+	main {
+		flex: 1;
+	}
+</style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4,8 +4,6 @@
 	let projects = $state(data.projects)
 </script>
 
-<main>
-	<Filters projectCount={projects.length} />
-	<ProjectCardContainer projectsData={data.projects} />
-	<About />
-</main>
+<Filters projectCount={projects.length} />
+<ProjectCardContainer projectsData={data.projects} />
+<About />


### PR DESCRIPTION
## What does this change?

Resolves issue #62

In this issue, I implemented a working error handler for our site. There is now a custom error page, which is intentionally very simple.

Due to limited time, we were not able to create a proper design for this page, but we did want to ensure that 404 errors are handled correctly.  
A new issue has been added to the backlog for creating a design for the error page.  
issue #162 

## Images
Before:
<img width="2879" height="1252" alt="Schermafbeelding 2026-01-14 112712" src="https://github.com/user-attachments/assets/74b6600f-4501-4275-a87e-563bd238bbd4" />


After:
<img width="2842" height="1514" alt="image" src="https://github.com/user-attachments/assets/63b21265-d02b-4232-8fe3-b4c83c075e91" />


<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


## How to review
Please test to make sure all invalid URLs are redirected to this page.  
Also, if possible, check on other devices to ensure works across devices aswell
