### PR TITLE
switch form buttons

### DIFF
--- a/src/lib/molecules/ProjectCard.svelte
+++ b/src/lib/molecules/ProjectCard.svelte
@@ -98,6 +98,7 @@
 		.date {
 			font-style: italic;
 			margin: 0 0 1rem 0;
+			justify-self: end;
 		}
 	}
 

--- a/src/lib/organisms/About.svelte
+++ b/src/lib/organisms/About.svelte
@@ -71,6 +71,7 @@
 		width: 120px;
 		transition: width 0.5s ease;
 		justify-content: start;
+		cursor: default;
 
 		@media (prefers-reduced-motion: reduce) {
 			transition: none;

--- a/src/lib/organisms/Filters.svelte
+++ b/src/lib/organisms/Filters.svelte
@@ -85,8 +85,8 @@
 		</fieldset>
 
 		<div class="form-buttons">
-			<button onclick={scrollTo}>Activeer filters</button>
 			<button onclick={resetFilters}>Reset filters</button>
+			<button onclick={scrollTo}>Activeer filters</button>
 		</div>
 	</form>
 


### PR DESCRIPTION
## What does this change?

Resolves issue #177

When filtering, after clicking the Activate filters button, users would naturally move to the Reset filters button.

To improve the user experience, I changed this behavior so that after clicking Activate filters, the focus moves to the project card section instead. This was done by switching the positions of the two buttons.

Now, once the filters are active, the user is taken directly to the project card container.

## Images
Before:  
<img width="2147" height="413" alt="image" src="https://github.com/user-attachments/assets/f4498f0c-8023-4c06-9b19-7542c64f6430" />


After;  
<img width="2170" height="426" alt="image" src="https://github.com/user-attachments/assets/b612d734-246a-4c20-85fc-13148c6b792c" />


## How to review
This is a very minor change that does not require much review.

In the HTML, I only switched the two buttons.
