### PR TITLE
fix: html elements in footer #148

### DIFF
--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -17,7 +17,7 @@ export { default as SponsorCarousel } from './organisms/SponsorCarousel.svelte';
 // component for loading in the details page content
 export { default as DetailsMain } from './organisms/DetailsMain.svelte';
 
-export { default as FooterInfo } from './organisms/FooterInfo.svelte';
+export { default as FooterInfo } from './organisms/Footer.svelte';
 
 // Images & Icons
 export { default as favicon } from './assets/favicon.svg';

--- a/src/lib/organisms/Footer.svelte
+++ b/src/lib/organisms/Footer.svelte
@@ -16,7 +16,7 @@
 </script>
 
 <footer class="footer">
-	<section class="footer-container">
+	<div class="footer-container">
 		<section class="footer-left">
 			<h2 class="project-title">Designing for recognition</h2>
 
@@ -48,14 +48,14 @@
 				other media that relate to the project.
 			</p>
 
-			<section class="brand-block">
+			<div class="brand-block">
 				<p class="brand-left">
 					<strong class="brand-line-1">CIVIC INTERACTION DESIGN</strong><br />
 					<em class="brand-line-2">RESEARCH GROUP</em>
 				</p>
-			</section>
+			</div>
 		</section>
-	</section>
+	</div>
 	<SponsorCarousel {sponsorsData} visible={showSponsors} />
 </footer>
 

--- a/src/lib/organisms/SponsorCarousel.svelte
+++ b/src/lib/organisms/SponsorCarousel.svelte
@@ -10,9 +10,7 @@
 </script>
 
 <section class="sponsors" style="display: {visible ? 'flex' : 'none'}">
-	<header class="title">
-		<h2>Onze partners</h2>
-	</header>
+	<h2>Onze partners</h2>
 
 	<!-- top and bottom row -->
 	{#each rowClasses as row}
@@ -21,9 +19,19 @@
 				{#each sponsorsData as sponsor}
 					<li>
 						<picture>
-							<source type="image/avif" srcset={`https://fdnd-agency.directus.app/assets/${sponsor.logo}?format=avif&fit=contain&quality=50`} />
-							<source type="image/webp" srcset={`https://fdnd-agency.directus.app/assets/${sponsor.logo}?format=webp&fit=contain&quality=50`} />
-							<img src={`https://fdnd-agency.directus.app/assets/${sponsor.logo}?format=png&fit=contain&quality=50`} alt={sponsor.name} loading="lazy" />
+							<source
+								type="image/avif"
+								srcset={`https://fdnd-agency.directus.app/assets/${sponsor.logo}?format=avif&fit=contain&quality=50`}
+							/>
+							<source
+								type="image/webp"
+								srcset={`https://fdnd-agency.directus.app/assets/${sponsor.logo}?format=webp&fit=contain&quality=50`}
+							/>
+							<img
+								src={`https://fdnd-agency.directus.app/assets/${sponsor.logo}?format=png&fit=contain&quality=50`}
+								alt={sponsor.name}
+								loading="lazy"
+							/>
 						</picture>
 					</li>
 				{/each}
@@ -44,17 +52,14 @@
 		margin-top: 2em;
 	}
 
-	.title {
-		padding-bottom: 16px;
-	}
-
-	.title h2 {
+	h2 {
 		color: var(--color-primary);
 		line-height: 1.2;
 		height: 2em;
+		padding-bottom: 16px;
 	}
 
-	.title h2::after {
+	h2::after {
 		content: '';
 		display: block;
 		height: 3px;


### PR DESCRIPTION
## What does this change?

Resolves issue #148 

This change addresses HTML validator warnings in the footer.
- Updated semantic HTML elements that were only used for styling purposes.
- The header element was replaced with a div, as it functions purely as a styling container.
- The “section without heading” was also only used for styling and has been replaced with a div.
- he remaining HTML validator messages were informational and related to trailing slashes on image URLs, which we did not change because Prettier reapplies them during formatting


## How to review

1. Run the HTML validator on the live site and observe the warnings related to footer elements.
2. Switch to this branch preview site, ( the newest one netlify generates) and run the HTML validator again.
3. Verify that the structural warnings are resolved and that only informational messages remain (trailing slashes on image URLs).
